### PR TITLE
added cp-kafka-connect image

### DIFF
--- a/cp-kafka-connect/Dockerfile
+++ b/cp-kafka-connect/Dockerfile
@@ -1,0 +1,5 @@
+FROM confluentinc/cp-server-connect:latest
+
+RUN confluent-hub install --no-prompt snowflakeinc/snowflake-kafka-connector:1.8.2 \
+   && confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.6.3 \
+   && confluent-hub install --no-prompt confluentinc/kafka-connect-salesforce-bulk-api:2.1.0


### PR DESCRIPTION
- [x] Add new docker image called `signal/cp-kafka-connect` that uses confluentic server-connect image and add our custom plugins

1. Navigate into `cp-kafka-connect` folder
2. Run `docker build . -t signal/cp-kafka-connect:latest`